### PR TITLE
feat: add details review page accessible from suit and rank stats

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,12 +5,15 @@ import InfoPanel from "./InfoPanel";
 import Login from "./Login";
 import GradingDashboard from "./GradingDashboard";
 import StatisticsDashboard from "./StatisticsDashboard";
+import ReviewDetails from "./ReviewDetails";
 import { AuthHelper } from "./AuthHelper";
 
 function App() {
   const [activeSection, setActiveSection] = useState('');
   const [currentView, setCurrentView] = useState('classifier');
   const [isAuthenticated, setIsAuthenticated] = useState(AuthHelper.isAuthenticated());
+  const [reviewFilterType, setReviewFilterType] = useState("");
+  const [reviewFilterValue, setReviewFilterValue] = useState("");
 
   // Check auth status on mount
   useEffect(() => {
@@ -48,7 +51,25 @@ function App() {
     }
 
     if (currentView === 'statistics') {
-      return <StatisticsDashboard />;
+      return (
+        <StatisticsDashboard
+          onViewDetails={(type, value) => {
+            setReviewFilterType(type);
+            setReviewFilterValue(value);
+            setCurrentView('review');
+          }}
+        />
+      );
+    }
+
+    if (currentView === 'review') {
+      return (
+        <ReviewDetails
+          filterType={reviewFilterType}
+          filterValue={reviewFilterValue}
+          onBack={() => setCurrentView('statistics')}
+        />
+      );
     }
 
     return (

--- a/frontend/src/ReviewDetails.jsx
+++ b/frontend/src/ReviewDetails.jsx
@@ -1,0 +1,216 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Container, Card, Row, Col, Button, Badge, Spinner, Alert } from 'react-bootstrap';
+import { AuthHelper } from './AuthHelper';
+
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'https://kwps65rcpf.execute-api.us-east-1.amazonaws.com/prod';
+
+export default function ReviewDetails({ filterType, filterValue, onBack }) {
+  const [cards, setCards] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetchDetails = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const headers = {};
+      const idToken = AuthHelper.getIdToken();
+      if (idToken) {
+        headers["Authorization"] = `Bearer ${idToken}`;
+      }
+      
+      const res = await fetch(
+        `${API_BASE_URL}/grading?action=details&filter_type=${filterType}&filter_value=${filterValue}&_=${Date.now()}`,
+        { headers }
+      );
+      
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      }
+      const data = await res.json();
+      setCards(data.cards || []);
+      setCurrentIndex(0);
+    } catch (err) {
+      setError(err.message || "Failed to load review details.");
+    } finally {
+      setLoading(false);
+    }
+  }, [filterType, filterValue]);
+
+  useEffect(() => {
+    fetchDetails();
+  }, [fetchDetails]);
+
+  // Handle keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (cards.length <= 1) return;
+      if (e.key === 'ArrowLeft') {
+        handlePrev();
+      } else if (e.key === 'ArrowRight') {
+        handleNext();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [cards, currentIndex]);
+
+  const handleNext = () => {
+    setCurrentIndex((prev) => (prev === cards.length - 1 ? 0 : prev + 1));
+  };
+
+  const handlePrev = () => {
+    setCurrentIndex((prev) => (prev === 0 ? cards.length - 1 : prev - 1));
+  };
+
+  if (loading) {
+    return (
+      <Container className="py-5 text-center">
+        <Spinner animation="border" variant="primary" className="mb-2" />
+        <p className="text-muted">Loading judgments...</p>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container className="py-4">
+        <Alert variant="danger">
+          <Alert.Heading>Error Loading Details</Alert.Heading>
+          <p>{error}</p>
+          <div className="d-flex gap-2">
+            <Button onClick={fetchDetails} variant="outline-danger">Try Again</Button>
+            <Button onClick={onBack} variant="secondary">Back to Stats</Button>
+          </div>
+        </Alert>
+      </Container>
+    );
+  }
+
+  if (cards.length === 0) {
+    return (
+      <Container className="py-4">
+        <Card className="text-center p-5 shadow-sm border-0 rounded-3">
+          <Card.Body>
+            <div className="fs-1 mb-3">🔍</div>
+            <Card.Title className="fw-bold">No judgments found</Card.Title>
+            <Card.Text className="text-muted">
+              No reviewed cards match the filter: <strong className="text-capitalize">{filterValue}</strong>.
+            </Card.Text>
+            <Button onClick={onBack} variant="primary">Back to Stats</Button>
+          </Card.Body>
+        </Card>
+      </Container>
+    );
+  }
+
+  const activeCard = cards[currentIndex];
+  const dateStr = activeCard.judged_at
+    ? new Date(activeCard.judged_at).toLocaleString()
+    : "Unknown Date";
+
+  const displayTitle = filterValue === "invalid" ? "Invalid Cards" : filterValue;
+
+  return (
+    <Container className="py-4">
+      <div className="d-flex align-items-center justify-content-between mb-4">
+        <Button onClick={onBack} variant="outline-secondary" className="d-flex align-items-center gap-2">
+          ← Back to Stats
+        </Button>
+        <h2 className="m-0 fw-bold text-capitalize text-center flex-grow-1">
+          Reviewing: {displayTitle}
+        </h2>
+        <div style={{ width: "130px" }} className="text-end text-muted fw-semibold">
+          Card {currentIndex + 1} of {cards.length}
+        </div>
+      </div>
+
+      <Row className="justify-content-center">
+        <Col md={10} lg={8}>
+          <Card className="shadow border-0 rounded-3 overflow-hidden">
+            <Row className="g-0">
+              {/* Image side */}
+              <Col md={6} className="bg-light d-flex align-items-center justify-content-center p-4 border-end">
+                {activeCard.image_url ? (
+                  <img
+                    src={activeCard.image_url}
+                    alt="Judged playing card"
+                    className="img-fluid rounded shadow-sm bg-white"
+                    style={{ maxHeight: "380px", objectFit: "contain" }}
+                  />
+                ) : (
+                  <div className="text-muted text-center py-5">
+                    <div className="fs-2 mb-2">📷</div>
+                    No image available
+                  </div>
+                )}
+              </Col>
+
+              {/* Data side */}
+              <Col md={6} className="d-flex flex-column justify-content-between p-4">
+                <div>
+                  <h4 className="fw-bold text-secondary mb-4 border-bottom pb-2">Judgment Details</h4>
+                  
+                  <div className="mb-3">
+                    <span className="text-muted d-block small">DATE SUBMITTED</span>
+                    <strong className="fs-6">{dateStr}</strong>
+                  </div>
+
+                  <div className="mb-3">
+                    <span className="text-muted d-block small">MODEL PREDICTION</span>
+                    <strong className="fs-5 text-primary text-capitalize">{activeCard.predicted_label}</strong>
+                    <div className="mt-1">
+                      <Badge bg={Number(activeCard.confidence) > 0.8 ? "success" : "warning"} className="py-1 px-2">
+                        Confidence: {(Number(activeCard.confidence) * 100).toFixed(1)}%
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div className="mb-4">
+                    <span className="text-muted d-block small">JUDGMENT STATUS</span>
+                    {activeCard.is_correct ? (
+                      <div>
+                        <Badge bg="success" className="py-2 px-3 fs-6 rounded-pill mt-1">
+                          ✓ Correct Prediction
+                        </Badge>
+                        <p className="text-muted small mt-2">The model guessed the card rank and suit correctly.</p>
+                      </div>
+                    ) : (
+                      <div>
+                        <Badge bg="danger" className="py-2 px-3 fs-6 rounded-pill mt-1">
+                          ✗ Incorrect (Corrected)
+                        </Badge>
+                        <div className="mt-2 p-2 bg-danger-subtle text-danger border border-danger-subtle rounded-2">
+                          <span className="small d-block text-muted">CORRECT LABEL:</span>
+                          <strong className="text-capitalize fs-6">{activeCard.actual_label}</strong>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Card navigation buttons */}
+                {cards.length > 1 && (
+                  <div className="d-flex gap-3 border-top pt-3 mt-4">
+                    <Button onClick={handlePrev} variant="outline-primary" className="w-50 fw-semibold">
+                      ◀ Previous
+                    </Button>
+                    <Button onClick={handleNext} variant="primary" className="w-50 fw-semibold">
+                      Next ▶
+                    </Button>
+                  </div>
+                )}
+              </Col>
+            </Row>
+          </Card>
+          {cards.length > 1 && (
+            <p className="text-center text-muted small mt-3">
+              Tip: Use the <strong>Left</strong> and <strong>Right</strong> arrow keys on your keyboard to page through the cards.
+            </p>
+          )}
+        </Col>
+      </Row>
+    </Container>
+  );
+}

--- a/frontend/src/StatisticsDashboard.jsx
+++ b/frontend/src/StatisticsDashboard.jsx
@@ -52,7 +52,7 @@ function AccuracyRing({ accuracy, size = 120, strokeWidth = 10 }) {
   );
 }
 
-export default function StatisticsDashboard() {
+export default function StatisticsDashboard({ onViewDetails }) {
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -192,9 +192,25 @@ export default function StatisticsDashboard() {
                 <span>Incorrect Guesses:</span>
                 <span className="fw-bold text-danger">{stats.total_judged - stats.total_correct}</span>
               </div>
-              <div className="d-flex justify-content-between py-2">
+              <div 
+                className="d-flex justify-content-between py-2 rounded-2 px-2"
+                style={{ 
+                  cursor: stats.total_invalid > 0 ? "pointer" : "default",
+                  transition: "background-color 0.2s"
+                }}
+                onClick={() => stats.total_invalid > 0 && onViewDetails && onViewDetails('special', 'invalid')}
+                onMouseEnter={(e) => stats.total_invalid > 0 && (e.currentTarget.style.backgroundColor = '#f8f9fa')}
+                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+              >
                 <span>Invalid Cards (Excluded):</span>
-                <span className="fw-bold text-warning">⚠️ {stats.total_invalid || 0}</span>
+                <span className="fw-bold text-warning" style={{ fontSize: '0.9rem' }}>
+                  ⚠️ {stats.total_invalid || 0}
+                  {stats.total_invalid > 0 && (
+                    <span className="text-muted ms-2 fw-normal" style={{ fontSize: '0.75rem' }}>
+                      (Click to review)
+                    </span>
+                  )}
+                </span>
               </div>
             </Card.Body>
           </Card>
@@ -205,12 +221,25 @@ export default function StatisticsDashboard() {
         {/* Suit breakdowns */}
         <Col md={6}>
           <Card className="shadow-sm border-0 rounded-3 p-4 h-100">
-            <h4 className="fw-bold mb-4 fs-5">Accuracy by Suit</h4>
+            <div className="d-flex align-items-baseline justify-content-between mb-4 flex-wrap gap-2">
+              <h4 className="fw-bold m-0 fs-5">Accuracy by Suit</h4>
+              <span className="text-muted small">(Click suit to review history)</span>
+            </div>
             {stats.accuracy_by_suit.map((s) => {
               const meta = suitMeta[s.suit] || { label: s.suit, hex: "#4A5568" };
               const acc = s.accuracy * 100;
               return (
-                <div key={s.suit} className="mb-3">
+                <div 
+                  key={s.suit} 
+                  className="mb-3 p-2 rounded-2" 
+                  style={{ 
+                    cursor: "pointer", 
+                    transition: "all 0.2s" 
+                  }}
+                  onClick={() => onViewDetails && onViewDetails('suit', s.suit)}
+                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#f8f9fa'}
+                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+                >
                   <div className="d-flex justify-content-between mb-1">
                     <span className="fw-semibold text-capitalize">{meta.label}</span>
                     <span className="text-muted">
@@ -239,7 +268,10 @@ export default function StatisticsDashboard() {
         {/* Rank breakdowns */}
         <Col md={6}>
           <Card className="shadow-sm border-0 rounded-3 p-4 h-100">
-            <h4 className="fw-bold mb-4 fs-5">Accuracy by Rank</h4>
+            <div className="d-flex align-items-baseline justify-content-between mb-4 flex-wrap gap-2">
+              <h4 className="fw-bold m-0 fs-5">Accuracy by Rank</h4>
+              <span className="text-muted small">(Click card to review history)</span>
+            </div>
             <div className="d-flex flex-wrap gap-2 justify-content-start">
               {stats.accuracy_by_rank.map((r) => {
                 const acc = r.accuracy * 100;
@@ -248,7 +280,24 @@ export default function StatisticsDashboard() {
                 else if (acc >= 70) bgClass = "bg-warning text-dark";
 
                 return (
-                  <Card key={r.rank} className="text-center shadow-none border" style={{ width: "90px" }}>
+                  <Card 
+                    key={r.rank} 
+                    className="text-center shadow-none border" 
+                    style={{ 
+                      width: "90px", 
+                      cursor: "pointer", 
+                      transition: "all 0.2s" 
+                    }}
+                    onClick={() => onViewDetails && onViewDetails('rank', r.rank)}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.transform = 'translateY(-3px)';
+                      e.currentTarget.style.boxShadow = '0 4px 8px rgba(0,0,0,0.05)';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.transform = 'none';
+                      e.currentTarget.style.boxShadow = 'none';
+                    }}
+                  >
                     <div className="bg-light py-1 fw-bold text-capitalize border-bottom fs-6" style={{ height: "30px", overflow: "hidden" }}>
                       {r.rank}
                     </div>

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -116,6 +116,10 @@ def lambda_handler(event, context):
                 action = query_params.get("action", "list")
                 if action == "stats":
                     return handle_get_stats(cors_headers)
+                elif action == "details":
+                    filter_type = query_params.get("filter_type", "")
+                    filter_value = query_params.get("filter_value", "")
+                    return handle_get_details(filter_type, filter_value, cors_headers)
                 
                 # Other GET actions (like action=list) require auth
                 if not is_admin_authorized(event):
@@ -431,6 +435,97 @@ def handle_submit_grading(body, cors_headers):
         "statusCode": 200,
         "headers": cors_headers,
         "body": json.dumps({"message": "Grading saved successfully.", "is_correct": is_correct})
+    }
+
+def handle_get_details(filter_type, filter_value, cors_headers):
+    s3 = boto3.client("s3")
+    bucket_name = os.environ.get("BUCKET_NAME")
+    if not bucket_name:
+        raise ValueError("BUCKET_NAME environment variable not set")
+        
+    s3_target_prefix = os.environ.get("S3_TARGET_PREFIX", "raw_data/")
+    if not s3_target_prefix.endswith('/'):
+        s3_target_prefix += '/'
+
+    # 1. List all json files in results/
+    keys = []
+    paginator = s3.get_paginator('list_objects_v2')
+    try:
+        for page in paginator.paginate(Bucket=bucket_name, Prefix="results/"):
+            for obj in page.get('Contents', []):
+                key = obj['Key']
+                if key.endswith(".json"):
+                    keys.append(key)
+    except Exception as e:
+        pass
+
+    results_data = []
+    def fetch_key(key):
+        try:
+            res_obj = s3.get_object(Bucket=bucket_name, Key=key)
+            return json.loads(res_obj["Body"].read().decode('utf-8'))
+        except Exception as e:
+            return None
+
+    # Load results in parallel
+    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+        futures = {executor.submit(fetch_key, key): key for key in keys}
+        for future in concurrent.futures.as_completed(futures):
+            data = future.result()
+            if data:
+                results_data.append(data)
+
+    # 2. Filter results
+    filtered_results = []
+    filter_value = filter_value.lower().strip()
+    
+    for r in results_data:
+        actual = r.get("actual_label", "")
+        
+        match = False
+        if filter_type == "special" and filter_value == "invalid":
+            if actual == "invalid":
+                match = True
+        elif actual != "invalid":
+            actual_rank, actual_suit = parse_card(actual)
+            if filter_type == "suit":
+                if actual_suit == filter_value:
+                    match = True
+            elif filter_type == "rank":
+                if actual_rank == filter_value:
+                    match = True
+                
+        if match:
+            # Generate pre-signed URL
+            req_id = r.get("request_id", "")
+            image_url = ""
+            if req_id:
+                try:
+                    image_url = s3.generate_presigned_url(
+                        'get_object',
+                        Params={'Bucket': bucket_name, 'Key': f"{s3_target_prefix}{req_id}/image.png"},
+                        ExpiresIn=3600
+                    )
+                except Exception:
+                    pass
+            
+            filtered_results.append({
+                "request_id": req_id,
+                "predicted_label": r.get("predicted_label"),
+                "actual_label": actual,
+                "confidence": r.get("confidence"),
+                "is_correct": r.get("is_correct"),
+                "judged_at": r.get("judged_at", r.get("timestamp")),
+                "image_url": image_url
+            })
+            
+    # Sort by judged_at or timestamp descending (newest first)
+    filtered_results.sort(key=lambda x: x.get("judged_at") or "", reverse=True)
+    
+    return {
+        "statusCode": 200,
+        "headers": cors_headers,
+        "body": json.dumps({"cards": filtered_results})
     }
 
 


### PR DESCRIPTION
- Create a paginated judgment detail review view (`ReviewDetails.jsx`) that renders the raw S3 card image, chronological index indicator (e.g. Card 3 of 15), date submitted, predicted label with confidence badge, and actual correction label if the guess was incorrect.
- Implement both visual button paging controls and native keyboard navigation support (using Left/Right arrow keys) to step through cards.
- Add pointer cursors and lift-on-hover micro-animations to the suit breakdown items and rank card widgets on the Statistics page.
- Map onClick callbacks on suits and ranks elements to load the detailed review.
- Add a public `action=details` handler in the Lambda router that filters judged items in parallel using a `ThreadPoolExecutor` and returns pre-signed card image URLs. Detailed Changes:
Backend (Lambda):
- Add `handle_get_details` function to list all S3 judged JSON objects, filter them by the clicked suit or rank, generate pre-signed raw card image URLs, and sort results chronologically (newest first).
- Register `action=details` in `lambda_handler`'s GET router bypassing Cognito checks to allow public access. Frontend (React):
- Add `ReviewDetails.jsx` component incorporating page navigation state, keyboard listeners, loading spinners, and styled result layouts.
- Integrate filter type, value, and review routing states inside `App.js`.
- Update `StatisticsDashboard.jsx` to declare an `onViewDetails` prop and attach hover event state style lifts to suits and rank widgets.
- Support filtering by `filter_type == "special"` and `filter_value == "invalid"` in the Lambda details endpoint, filtering for items with an actual label marked as "invalid".
- Make the "Invalid Cards (Excluded)" row in the "System Summary" widget on the Stats Dashboard interactive. When clicked, it routes the user to the review details page with all invalid card uploads.
- Custom-format the review page title to read "Reviewing: Invalid Cards" when viewing the invalid list, rather than showing the raw filter string value.
- Create a paginated judgment detail review view (`ReviewDetails.jsx`) to render raw S3 card images, chronological index count, date, predicted label with confidence, and actual correction label for incorrect predictions.
- Support keyboard Left/Right arrow navigation to step through card history.
- Map onClick callbacks on suits, ranks, and invalid cards to load the review.
- Add descriptive instructional helper labels:
  - "(Click suit to review history)" in the Suit breakdown header
  - "(Click card to review history)" in the Rank breakdown header
  - "(Click to review)" next to the Invalid Cards row count in System Summary
- Expose a public `action=details` handler in Lambda filtering by suit, rank, or special status (such as invalid uploads), returning pre-signed S3 image URLs.